### PR TITLE
No.21 ステータス一括更新処理修正

### DIFF
--- a/src/main/java/com/example/service/CampaignService.java
+++ b/src/main/java/com/example/service/CampaignService.java
@@ -122,7 +122,7 @@ public class CampaignService {
 	 * @param nexStatus 更新後ステータス
 	 * @throws Exception
 	 */
-	@Transactional(readOnly = false, rollbackFor = RuntimeException.class)
+	@Transactional(readOnly = false, rollbackFor = Exception.class)
 	public void bulkStatusUpdate(List<Long> idList, CampaignStatus nexStatus) throws Exception {
 		try {
 			idList.forEach(id -> {
@@ -134,7 +134,7 @@ public class CampaignService {
 				campaign.setStatus(nexStatus);
 				campaignRepository.save(campaign);
 			});
-		} catch (RuntimeException e) {
+		} catch (Exception e) {
 			throw new Exception(e.getMessage());
 		}
 	}


### PR DESCRIPTION
キャンペーン一覧画面にて複数のステータスを一括処理する際にエラー発生前のみ更新されていたのを、エラーが発生した場合何も更新されないように修正。